### PR TITLE
Run on all events, but filter to what we want

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,26 @@
 on:
   pull_request:
-    types: [assigned, opened, reopened, ready_for_review, review_requested]
+    types:
+      [
+        assigned,
+        unassigned,
+        labeled,
+        unlabeled,
+        opened,
+        edited,
+        closed,
+        reopened,
+        synchronize,
+        ready_for_review,
+        locked,
+        unlocked,
+        review_requested,
+        review_request_removed,
+      ]
   pull_request_review:
     types: [submitted, edited, dismissed]
   pull_request_review_comment:
-    types: [created]
+    types: [created, edited, deleted]
 
 jobs:
   pull_request_notifier:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,10 @@
-on: pull_request
+on:
+  pull_request:
+    types: [assigned, opened, reopened, ready_for_review, review_requested]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created]
 
 jobs:
   pull_request_notifier:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,4 @@
-on:
-  pull_request:
-    types: [review_requested]
+on: pull_request
 
 jobs:
   pull_request_notifier:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,29 @@
 2. Drop the following file into your repo at path `.github/workflows/notify.yml` (editing `GITHUB_FIELD_NAME` as appropriate)
 
 ```
-on: pull_request
+on:
+  pull_request:
+    types:
+      [
+        assigned,
+        unassigned,
+        labeled,
+        unlabeled,
+        opened,
+        edited,
+        closed,
+        reopened,
+        synchronize,
+        ready_for_review,
+        locked,
+        unlocked,
+        review_requested,
+        review_request_removed
+      ]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
 
 jobs:
   pull_request_notifier:

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 2. Drop the following file into your repo at path `.github/workflows/notify.yml` (editing `GITHUB_FIELD_NAME` as appropriate)
 
 ```
-on:
-  pull_request:
-    types: [review_requested]
+on: pull_request
 
 jobs:
   pull_request_notifier:

--- a/dist/index.js
+++ b/dist/index.js
@@ -54617,7 +54617,7 @@ const handleReviewRequested = function (context) {
 };
 
 const main = function (context) {
-  console.log('[hf] context', JSON.stringify(context));
+  console.log("[hf] context", JSON.stringify(context));
   if (context.payload.action === "review_requested") {
     handleReviewRequested(context);
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -54496,7 +54496,7 @@ const githubFieldName = process.env.GITHUB_FIELD_NAME;
 const token = process.env.SLACK_BOT_TOKEN;
 const slack = new WebClient(token);
 
-const prApprovalImg = "https://i.imgur.com/41zA3Ek.png"
+const prApprovalImg = "https://i.imgur.com/41zA3Ek.png";
 
 const slackMessageTemplateNewPR = function (requestUser, pr) {
   return [
@@ -54534,8 +54534,8 @@ const slackMessageTemplateApprovedPR = function (reviewUser, pr) {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `${reviewUser} has approved ${pr.title}: `
-      }
+        text: `${reviewUser} has approved ${pr.title}: `,
+      },
     },
     {
       type: "divider",
@@ -54552,8 +54552,8 @@ const slackMessageTemplateApprovedPR = function (reviewUser, pr) {
         alt_text: "LGTM",
       },
     },
-  ]
-}
+  ];
+};
 
 const sendSlackMessage = function (reviewUser, requestUser, pr) {
   return slack.chat.postMessage({
@@ -54592,7 +54592,7 @@ const getPullRequestData = function (payload) {
   });
 };
 
-const main = function (context) {
+const handleReviewRequested = function (context) {
   const pullRequestData = getPullRequestData(context.payload);
 
   const requesterPromise = getOktaUser(pullRequestData.requester)
@@ -54614,6 +54614,12 @@ const main = function (context) {
     .catch(function (err) {
       core.setFailed(err.message);
     });
+};
+
+const main = function (context) {
+  if (context.payload.action === "review_requested") {
+    handleReviewRequested(context);
+  }
 };
 
 main(github.context);

--- a/dist/index.js
+++ b/dist/index.js
@@ -54583,17 +54583,13 @@ const getSlackNameByEmail = function (email) {
   return slack.users.lookupByEmail({ email: email }).then((r) => r.user.name);
 };
 
-const getPullRequestData = function (payload) {
-  return Object.create({
-    title: payload.pull_request.title,
-    url: payload.pull_request.html_url,
-    reviewer: payload.requested_reviewer.login,
-    requester: payload.pull_request.user.login,
-  });
-};
-
 const handleReviewRequested = function (context) {
-  const pullRequestData = getPullRequestData(context.payload);
+  const pullRequestData = Object.create({
+    title: context.payload.pull_request.title,
+    url: context.payload.pull_request.html_url,
+    reviewer: context.payload.requested_reviewer.login,
+    requester: context.payload.pull_request.user.login,
+  });
 
   const requesterPromise = getOktaUser(pullRequestData.requester)
     .then(getUserEmailByGithub)
@@ -54617,8 +54613,10 @@ const handleReviewRequested = function (context) {
 };
 
 const main = function (context) {
-  console.log("[hf] context", JSON.stringify(context));
-  if (context.payload.action === "review_requested") {
+  if (
+    context.eventName === "pull_request" &&
+    context.payload.action === "review_requested"
+  ) {
     handleReviewRequested(context);
   }
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -54617,6 +54617,7 @@ const handleReviewRequested = function (context) {
 };
 
 const main = function (context) {
+  console.log('[hf] context', JSON.stringify(context));
   if (context.payload.action === "review_requested") {
     handleReviewRequested(context);
   }

--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ const handleReviewRequested = function (context) {
 };
 
 const main = function (context) {
-  console.log('[hf] context', JSON.stringify(context));
+  console.log("[hf] context", JSON.stringify(context));
   if (context.payload.action === "review_requested") {
     handleReviewRequested(context);
   }

--- a/index.js
+++ b/index.js
@@ -99,17 +99,13 @@ const getSlackNameByEmail = function (email) {
   return slack.users.lookupByEmail({ email: email }).then((r) => r.user.name);
 };
 
-const getPullRequestData = function (payload) {
-  return Object.create({
-    title: payload.pull_request.title,
-    url: payload.pull_request.html_url,
-    reviewer: payload.requested_reviewer.login,
-    requester: payload.pull_request.user.login,
-  });
-};
-
 const handleReviewRequested = function (context) {
-  const pullRequestData = getPullRequestData(context.payload);
+  const pullRequestData = Object.create({
+    title: context.payload.pull_request.title,
+    url: context.payload.pull_request.html_url,
+    reviewer: context.payload.requested_reviewer.login,
+    requester: context.payload.pull_request.user.login,
+  });
 
   const requesterPromise = getOktaUser(pullRequestData.requester)
     .then(getUserEmailByGithub)
@@ -133,8 +129,10 @@ const handleReviewRequested = function (context) {
 };
 
 const main = function (context) {
-  console.log("[hf] context", JSON.stringify(context));
-  if (context.payload.action === "review_requested") {
+  if (
+    context.eventName === "pull_request" &&
+    context.payload.action === "review_requested"
+  ) {
     handleReviewRequested(context);
   }
 };

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const githubFieldName = process.env.GITHUB_FIELD_NAME;
 const token = process.env.SLACK_BOT_TOKEN;
 const slack = new WebClient(token);
 
-const prApprovalImg = "https://i.imgur.com/41zA3Ek.png"
+const prApprovalImg = "https://i.imgur.com/41zA3Ek.png";
 
 const slackMessageTemplateNewPR = function (requestUser, pr) {
   return [
@@ -50,8 +50,8 @@ const slackMessageTemplateApprovedPR = function (reviewUser, pr) {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `${reviewUser} has approved ${pr.title}: `
-      }
+        text: `${reviewUser} has approved ${pr.title}: `,
+      },
     },
     {
       type: "divider",
@@ -68,8 +68,8 @@ const slackMessageTemplateApprovedPR = function (reviewUser, pr) {
         alt_text: "LGTM",
       },
     },
-  ]
-}
+  ];
+};
 
 const sendSlackMessage = function (reviewUser, requestUser, pr) {
   return slack.chat.postMessage({
@@ -108,7 +108,7 @@ const getPullRequestData = function (payload) {
   });
 };
 
-const main = function (context) {
+const handleReviewRequested = function (context) {
   const pullRequestData = getPullRequestData(context.payload);
 
   const requesterPromise = getOktaUser(pullRequestData.requester)
@@ -130,6 +130,12 @@ const main = function (context) {
     .catch(function (err) {
       core.setFailed(err.message);
     });
+};
+
+const main = function (context) {
+  if (context.payload.action === "review_requested") {
+    handleReviewRequested(context);
+  }
 };
 
 main(github.context);

--- a/index.js
+++ b/index.js
@@ -133,6 +133,7 @@ const handleReviewRequested = function (context) {
 };
 
 const main = function (context) {
+  console.log('[hf] context', JSON.stringify(context));
   if (context.payload.action === "review_requested") {
     handleReviewRequested(context);
   }


### PR DESCRIPTION
We will probably want to subscribe to more than just review_requested in the future, and we don't want to have to go to every repo and update the notify.yml file. So, instead, subscribe to all events, but just filter on the pull_request action type