### PR TITLE
Slack has a max length on message accessory text

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -54638,6 +54638,14 @@ const githubFieldName = process.env.GITHUB_FIELD_NAME;
 const token = process.env.SLACK_BOT_TOKEN;
 const slack = new WebClient(token);
 
+const ellipsize = function (text, maxLen) {
+  if (text.length <= maxLen) {
+    return text;
+  }
+  const ellipsis = "...";
+  return text.slice(0, maxLen - ellipsis.length) + ellipsis;
+};
+
 const slackMessageTemplateNewPR = function (requestUser, pr) {
   return [
     {
@@ -54660,7 +54668,7 @@ const slackMessageTemplateNewPR = function (requestUser, pr) {
         type: "button",
         text: {
           type: "plain_text",
-          text: pr.title,
+          text: ellipsize(pr.title, 75),
         },
         url: pr.url,
       },
@@ -54696,7 +54704,7 @@ const slackMessageTemplateReviewedPR = function (reviewUser, pr) {
         type: "button",
         text: {
           type: "plain_text",
-          text: pr.title,
+          text: ellipsize(pr.title, 75),
         },
         url: pr.url,
       },

--- a/index.js
+++ b/index.js
@@ -14,6 +14,14 @@ const githubFieldName = process.env.GITHUB_FIELD_NAME;
 const token = process.env.SLACK_BOT_TOKEN;
 const slack = new WebClient(token);
 
+const ellipsize = function (text, maxLen) {
+  if (text.length <= maxLen) {
+    return text;
+  }
+  const ellipsis = "...";
+  return text.slice(0, maxLen - ellipsis.length) + ellipsis;
+};
+
 const slackMessageTemplateNewPR = function (requestUser, pr) {
   return [
     {
@@ -36,7 +44,7 @@ const slackMessageTemplateNewPR = function (requestUser, pr) {
         type: "button",
         text: {
           type: "plain_text",
-          text: pr.title,
+          text: ellipsize(pr.title, 75),
         },
         url: pr.url,
       },
@@ -72,7 +80,7 @@ const slackMessageTemplateReviewedPR = function (reviewUser, pr) {
         type: "button",
         text: {
           type: "plain_text",
-          text: pr.title,
+          text: ellipsize(pr.title, 75),
         },
         url: pr.url,
       },


### PR DESCRIPTION
Some github bot notifs have been failing to send due to long PR titles. So: cap the text length and add "..." if needed

context: https://github.com/calm/api/runs/4958993731?check_suite_focus=true